### PR TITLE
feat: Remove sex requirements from TTS voice selection and improved selection UI

### DIFF
--- a/Content.Client/Lobby/UI/HumanoidProfileEditor.TTS.cs
+++ b/Content.Client/Lobby/UI/HumanoidProfileEditor.TTS.cs
@@ -1,5 +1,6 @@
-﻿using System.Linq;
+using System.Linq;
 using Content.Client.TTS;
+using Content.Shared.Humanoid;
 using Content.Shared.Preferences;
 using Content.Shared.TTS;
 using Robust.Shared.Random;
@@ -33,11 +34,19 @@ public sealed partial class HumanoidProfileEditor
         _voiceList = _prototypeManager
             .EnumeratePrototypes<TTSVoicePrototype>()
             .Where(o => o.CanSelect)
-            .OrderBy(o => Loc.GetString(o.Name))
+            .OrderBy(o => o.Sex)
+            .ThenBy(o => Loc.GetString(o.Name))
             .ToList();
 
         VoiceButton.OnItemSelected += args =>
         {
+            if (args.Id < 0)
+            {
+                var currentVoiceId = _voiceList.FindIndex(x => x.ID == Profile?.Voice);
+                VoiceButton.SelectId(currentVoiceId);
+                return;
+            }
+
             VoiceButton.SelectId(args.Id);
             SetVoice(_voiceList[args.Id].ID);
         };
@@ -52,19 +61,31 @@ public sealed partial class HumanoidProfileEditor
 
         VoiceButton.Clear();
 
-        var firstVoiceChoiceId = 1;
+        var firstVoiceChoiceId = 0;
+        Sex? lastSex = null;
         for (var i = 0; i < _voiceList.Count; i++)
         {
             var voice = _voiceList[i];
-            if (!HumanoidCharacterProfile.CanHaveVoice(voice, Profile.Sex))
-                continue;
+
+            if (lastSex != voice.Sex)
+            {
+                var categoryLoc = voice.Sex switch
+                {
+                    Sex.Male => "humanoid-profile-editor-voice-category-masculine",
+                    Sex.Female => "humanoid-profile-editor-voice-category-feminine",
+                    _ => "humanoid-profile-editor-voice-category-unsexed"
+                };
+                
+                // Use unique negative IDs for headers and disable them
+                var headerId = -(int)voice.Sex - 1;
+                VoiceButton.AddItem(Loc.GetString(categoryLoc), headerId);
+                VoiceButton.SetItemDisabled(VoiceButton.ItemCount - 1, true);
+                
+                lastSex = voice.Sex;
+            }
 
             var name = Loc.GetString(voice.Name);
             VoiceButton.AddItem(name, i);
-
-            if (firstVoiceChoiceId == 1)
-                firstVoiceChoiceId = i;
-
         }
 
         var voiceChoiceId = _voiceList.FindIndex(x => x.ID == Profile.Voice);

--- a/Content.Shared/Preferences/HumanoidCharacterProfile.cs
+++ b/Content.Shared/Preferences/HumanoidCharacterProfile.cs
@@ -601,7 +601,7 @@ namespace Content.Shared.Preferences
             name = name.Trim();
 
             prototypeManager.TryIndex<TTSVoicePrototype>(Voice, out var voice);
-            if (voice is null || !CanHaveVoice(voice, Sex))
+            if (voice is null || !voice.CanSelect)
                 Voice = SharedHumanoidAppearanceSystem.DefaultSexVoice[sex];
 
             if (configManager.GetCVar(CCVars.RestrictedNames) && Species != "IPC")
@@ -747,7 +747,7 @@ namespace Content.Shared.Preferences
 
         public static bool CanHaveVoice(TTSVoicePrototype voice, Sex sex)
         {
-            return voice.CanSelect && sex == Sex.Unsexed || (voice.Sex == sex || voice.Sex == Sex.Unsexed);
+            return voice.CanSelect;
         }
 
 

--- a/Content.Shared/TTS/TTSVoicePrototype.cs
+++ b/Content.Shared/TTS/TTSVoicePrototype.cs
@@ -14,8 +14,8 @@ public sealed partial class TTSVoicePrototype : IPrototype
     [DataField("name")]
     public string Name { get; private set; } = string.Empty;
 
-    [DataField(required: true)]
-    public Sex Sex;
+    [DataField]
+    public Sex Sex = Sex.Unsexed;
 
     [DataField(required: true)]
     public string Model = string.Empty;

--- a/Resources/Locale/en-US/tts/ui.ftl
+++ b/Resources/Locale/en-US/tts/ui.ftl
@@ -2,3 +2,6 @@ ui-options-tts-volume = TTS Volume
 
 humanoid-profile-editor-voice-label = Voice
 humanoid-profile-editor-voice-play = Test
+humanoid-profile-editor-voice-category-masculine = --- Masculine ---
+humanoid-profile-editor-voice-category-feminine = --- Feminine ---
+humanoid-profile-editor-voice-category-unsexed = --- Other ---

--- a/Resources/Prototypes/TTS/voices.yml
+++ b/Resources/Prototypes/TTS/voices.yml
@@ -1,3 +1,12 @@
+# TTS Voice Prototype Template:
+# - type: ttsVoice
+#   id: InternalID (Unique string)
+#   name: DisplayName (Can be a raw string or a localization key)
+#   model: turbo (Current standard model)
+#   sex: [Male | Female | Unsexed] (Optional, defaults to Unsexed if omitted)
+#   speaker: API speaker name/ID (Determines the actual voice used)
+#   canSelect: true (Optional, whether players can pick it in the character menu, defaults to true)
+
 - type: ttsVoice
   id: Abigail
   name: Abigail
@@ -233,14 +242,6 @@
   id: Meow
   name: Meow
   model: turbo
-  sex: Male
-  speaker: Meow
-
-- type: ttsVoice
-  id: Meow
-  name: Meow
-  model: turbo
-  sex: Female
   speaker: Meow
 
 - type: ttsVoice


### PR DESCRIPTION


## About the PR
<!-- What did you change? -->
<!-- If this is a code change, summarize at high level how your new code works. This makes it easier to review. -->

*   **Shared Changes**:
    *   Removed strict sex-based filtering for TTS voices in `HumanoidCharacterProfile`.
    *   Modified `TTSVoicePrototype` to make the `Sex` field optional, with a default value of `Unsexed`.
    *   Updated character profile validation to only fallback to a default voice if the selected one is missing or unselectable.
*   **Client UI Improvements**:
    *   Organized the voice selection dropdown into categorized groups: **Masculine**, **Feminine**, and **Other**.
    *   Implemented non-selectable category headers with unique IDs to prevent client crashes and improve navigation.
    *   Voices are now sorted by sex category and then alphabetically by name.
*   **Resources & Localization**:
    *   Added localized strings for the new voice category headers in `ui.ftl`.
    *   Added a commented documentation template for voice prototypes at the top of `voices.yml` for future reference.